### PR TITLE
fix: disable pull down to dissmiss [SI-783]

### DIFF
--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -94,6 +94,7 @@ typedef enum : NSUInteger {
     picker.colsInPortrait = 4;
     picker.colsInLandscape = 6;
     picker.minimumInteritemSpacing = 2.0;
+    picker.modalPresentationStyle = UIModalPresentationFullScreen;
 
     if(!disable_popover) {
         picker.modalPresentationStyle = UIModalPresentationPopover;


### PR DESCRIPTION
Starting iOS 13 ImagePicker was displayed in a modal due to iOS changes. Modal could be dismissed by pull down.
In this case plugin do not work - it doesn't resolves or rejects and Mobile business logic fails

In JIRA ticket comments I found this issue with modals was fixed on ReactNative, Cpacitor (from Ionic Team). But not on the Telerik ImagePicker (though iOS 13 arrived in Semtember 2019). 
I can't grasp how to fix pull behavior to rise a reject (like a Cancel button do) but I can disable this pull down to dismiss behavior.
So with this fix ImagePicker modal can't be dismissed by pull down.

Since we didn't  used this repo for a while, I've created a PR with an update to the latest version of the original ImagePicker: #2

Jira: [SI-783]

[SI-783]: https://simplifield.atlassian.net/browse/SI-783