### PR TITLE
fix: android 10+ [SI-797]

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -97,7 +97,9 @@
                 <param name="android-package" value="com.synconset.ImagePicker"/>
             </feature>
         </config-file>
-
+        <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
+            <application android:requestLegacyExternalStorage="true" />
+        </edit-config>
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <activity android:label="@string/multi_app_name" android:name="com.synconset.MultiImageChooserActivity" android:theme="@style/Theme.AppCompat.Light">
             </activity>


### PR DESCRIPTION
Add a config fix to make the plugin work on Android 10 (Works only if targetSdk in the `build.gradle` is set to 29)

UPD: It's not working. It fails in runtime with console errors about manifest errors